### PR TITLE
Implement lc CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,43 @@
-Log Cache CLI Plugin
-====================
+Log Cache CLI
+=============
+
 [![GoDoc][go-doc-badge]][go-doc] [![travis][travis-badge]][travis] [![slack.cloudfoundry.org][slack-badge]][loggregator-slack]
+
+This repo contains the following:
+
+ - Stand alone CLI for Log Cache
+ - Cloud Foundry CLI plugin for Log Cache
+
+## Stand alone CLI
+
+### Installing CLI
+
+Run our install script:
+
+```
+curl -sS https://raw.githubusercontent.com/cloudfoundry/log-cache-cli/develop/scripts/install.sh | bash
+```
+
+### Usage
+
+1. Target the Log Cache by setting the environment variable `LOG_CACHE_ADDR`.
+1. Simply run the `log-cache` command to view current metrics stored in Log
+   Cache.
+1. Help can be accessed with the `--help` flag at any command level.
+
+```
+$ log-cache tail --help
+Output logs and metrics for a given source-id
+
+Usage:
+  log-cache tail <source-id> [flags]
+
+Flags:
+  -f, --follow   Output appended to stdout as logs are egressed.
+  -h, --help     help for tail
+```
+
+## Cloud Foundry CLI plugin
 
 The Log Cache CLI Plugin is a [CF CLI](cf-cli) plugin for the [Log
 Cache](log-cache) system.
@@ -13,8 +50,6 @@ cf install-plugin $GOPATH/bin/log-cache-cli
 ```
 
 ### Usage
-
-##### `log-cache`
 
 ```
 $ cf tail --help
@@ -38,8 +73,6 @@ OPTIONS:
    --end-time            End of query range in UNIX nanoseconds.
    --envelope-type       Envelope type filter. Available filters: 'log', 'counter', 'gauge', 'timer', and 'event'.
 ```
-
-##### `log-cache-meta`
 
 ```
 $ cf log-meta --help

--- a/cmd/cf-lc-plugin/cf_log_cache_plugin_suite_test.go
+++ b/cmd/cf-lc-plugin/cf_log_cache_plugin_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestLogCacheCli(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "LogCacheCli Suite")
+	RunSpecs(t, "CF Log Cache Plugin Suite")
 }

--- a/cmd/cf-lc-plugin/main.go
+++ b/cmd/cf-lc-plugin/main.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/cli/plugin"
-	"code.cloudfoundry.org/log-cache-cli/internal/command"
+	"code.cloudfoundry.org/log-cache-cli/pkg/command/cf"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -23,7 +23,7 @@ var version string
 
 type LogCacheCLI struct{}
 
-var commands = make(map[string]command.Command)
+var commands = make(map[string]cf.Command)
 
 func (c *LogCacheCLI) Run(conn plugin.CliConnection, args []string) {
 	if len(args) == 1 && args[0] == "CLI-MESSAGE-UNINSTALL" {
@@ -37,20 +37,20 @@ func (c *LogCacheCLI) Run(conn plugin.CliConnection, args []string) {
 
 	isTerminal := terminal.IsTerminal(int(os.Stdout.Fd()))
 
-	commands["tail"] = func(ctx context.Context, cli plugin.CliConnection, args []string, c command.HTTPClient, log command.Logger, tableWriter io.Writer) {
-		var opts []command.TailOption
+	commands["tail"] = func(ctx context.Context, cli plugin.CliConnection, args []string, c cf.HTTPClient, log cf.Logger, tableWriter io.Writer) {
+		var opts []cf.TailOption
 		if !isTerminal {
-			opts = append(opts, command.WithTailNoHeaders())
+			opts = append(opts, cf.WithTailNoHeaders())
 		}
-		command.Tail(ctx, cli, args, c, log, tableWriter, opts...)
+		cf.Tail(ctx, cli, args, c, log, tableWriter, opts...)
 	}
 
-	commands["log-meta"] = func(ctx context.Context, cli plugin.CliConnection, args []string, c command.HTTPClient, log command.Logger, tableWriter io.Writer) {
-		var opts []command.MetaOption
+	commands["log-meta"] = func(ctx context.Context, cli plugin.CliConnection, args []string, c cf.HTTPClient, log cf.Logger, tableWriter io.Writer) {
+		var opts []cf.MetaOption
 		if !isTerminal {
-			opts = append(opts, command.WithMetaNoHeaders())
+			opts = append(opts, cf.WithMetaNoHeaders())
 		}
-		command.Meta(
+		cf.Meta(
 			ctx,
 			cli,
 			func(sourceID string, start, end time.Time) []string {
@@ -66,7 +66,7 @@ func (c *LogCacheCLI) Run(conn plugin.CliConnection, args []string) {
 					"--lines", "1000",
 				}
 
-				command.Tail(
+				cf.Tail(
 					ctx,
 					cli,
 					args,

--- a/cmd/lc/lc_suite_test.go
+++ b/cmd/lc/lc_suite_test.go
@@ -1,0 +1,13 @@
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLc(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Log Cache CLI Suite")
+}

--- a/cmd/lc/main.go
+++ b/cmd/lc/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"os"
+
+	"code.cloudfoundry.org/log-cache-cli/pkg/command"
+)
+
+func main() {
+	if command.Execute(command.WithOutput(os.Stdout)) != nil {
+		os.Exit(1)
+	}
+}

--- a/pkg/command/cf/command_suite_test.go
+++ b/pkg/command/cf/command_suite_test.go
@@ -1,4 +1,4 @@
-package command_test
+package cf_test
 
 import (
 	"errors"

--- a/pkg/command/cf/formatter.go
+++ b/pkg/command/cf/formatter.go
@@ -1,4 +1,4 @@
-package command
+package cf
 
 import (
 	"bytes"

--- a/pkg/command/cf/meta.go
+++ b/pkg/command/cf/meta.go
@@ -1,4 +1,4 @@
-package command
+package cf
 
 import (
 	"context"

--- a/pkg/command/cf/meta_test.go
+++ b/pkg/command/cf/meta_test.go
@@ -1,4 +1,4 @@
-package command_test
+package cf_test
 
 import (
 	"bytes"
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"code.cloudfoundry.org/log-cache-cli/internal/command"
+	"code.cloudfoundry.org/log-cache-cli/pkg/command/cf"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -50,7 +50,7 @@ var _ = Describe("Meta", func() {
 		}
 		cliConn.cliCommandErr = nil
 
-		command.Meta(
+		cf.Meta(
 			context.Background(),
 			cliConn,
 			nil,
@@ -101,7 +101,7 @@ var _ = Describe("Meta", func() {
 		}
 		cliConn.cliCommandErr = nil
 
-		command.Meta(
+		cf.Meta(
 			context.Background(),
 			cliConn,
 			nil,
@@ -109,7 +109,7 @@ var _ = Describe("Meta", func() {
 			httpClient,
 			logger,
 			tableWriter,
-			command.WithMetaNoHeaders(),
+			cf.WithMetaNoHeaders(),
 		)
 
 		Expect(strings.Split(tableWriter.String(), "\n")).To(Equal([]string{
@@ -139,7 +139,7 @@ var _ = Describe("Meta", func() {
 		}
 		cliConn.cliCommandErr = nil
 
-		command.Meta(
+		cf.Meta(
 			context.Background(),
 			cliConn,
 			nil,
@@ -199,7 +199,7 @@ var _ = Describe("Meta", func() {
 		}
 		cliConn.cliCommandErr = nil
 
-		command.Meta(
+		cf.Meta(
 			context.Background(),
 			cliConn,
 			nil,
@@ -272,7 +272,7 @@ var _ = Describe("Meta", func() {
 		}
 		cliConn.cliCommandErr = nil
 
-		command.Meta(
+		cf.Meta(
 			context.Background(),
 			cliConn,
 			tailer,
@@ -313,7 +313,7 @@ var _ = Describe("Meta", func() {
 		}
 		cliConn.cliCommandErr = nil
 
-		command.Meta(
+		cf.Meta(
 			context.Background(),
 			cliConn,
 			nil,
@@ -375,7 +375,7 @@ var _ = Describe("Meta", func() {
 		cliConn.cliCommandErr = nil
 
 		args := []string{"--source-type", "application"}
-		command.Meta(
+		cf.Meta(
 			context.Background(),
 			cliConn,
 			nil,
@@ -417,7 +417,7 @@ var _ = Describe("Meta", func() {
 		cliConn.cliCommandErr = nil
 
 		args := []string{"--source-type", "service"}
-		command.Meta(
+		cf.Meta(
 			context.Background(),
 			cliConn,
 			nil,
@@ -459,7 +459,7 @@ var _ = Describe("Meta", func() {
 		cliConn.cliCommandErr = nil
 
 		args := []string{"--source-type", "PLATFORM"}
-		command.Meta(
+		cf.Meta(
 			context.Background(),
 			cliConn,
 			nil,
@@ -500,7 +500,7 @@ var _ = Describe("Meta", func() {
 		cliConn.cliCommandErr = nil
 
 		args := []string{"--source-type", "all"}
-		command.Meta(
+		cf.Meta(
 			context.Background(),
 			cliConn,
 			nil,
@@ -543,7 +543,7 @@ var _ = Describe("Meta", func() {
 		cliConn.cliCommandErr = nil
 
 		args := []string{"--source-type", "PLATFORM", "--guid"}
-		command.Meta(
+		cf.Meta(
 			context.Background(),
 			cliConn,
 			nil,
@@ -591,7 +591,7 @@ var _ = Describe("Meta", func() {
 		}
 		cliConn.cliCommandErr = nil
 
-		command.Meta(
+		cf.Meta(
 			context.Background(),
 			cliConn,
 			nil,
@@ -651,7 +651,7 @@ var _ = Describe("Meta", func() {
 		}
 		cliConn.cliCommandErr = nil
 
-		command.Meta(
+		cf.Meta(
 			context.Background(),
 			cliConn,
 			nil,
@@ -683,7 +683,7 @@ var _ = Describe("Meta", func() {
 		}
 		cliConn.cliCommandErr = nil
 
-		command.Meta(
+		cf.Meta(
 			context.Background(),
 			cliConn,
 			nil,
@@ -698,7 +698,7 @@ var _ = Describe("Meta", func() {
 
 	It("fatally logs when it receives too many arguments", func() {
 		Expect(func() {
-			command.Meta(
+			cf.Meta(
 				context.Background(),
 				cliConn,
 				nil,
@@ -715,7 +715,7 @@ var _ = Describe("Meta", func() {
 	It("fatally logs when scope is not 'platform', 'application' or 'all'", func() {
 		args := []string{"--source-type", "invalid"}
 		Expect(func() {
-			command.Meta(
+			cf.Meta(
 				context.Background(),
 				cliConn,
 				nil,
@@ -733,7 +733,7 @@ var _ = Describe("Meta", func() {
 		cliConn.apiEndpointErr = errors.New("some-error")
 
 		Expect(func() {
-			command.Meta(
+			cf.Meta(
 				context.Background(),
 				cliConn,
 				nil,
@@ -756,7 +756,7 @@ var _ = Describe("Meta", func() {
 		cliConn.cliCommandErr = []error{errors.New("some-error")}
 
 		Expect(func() {
-			command.Meta(
+			cf.Meta(
 				context.Background(),
 				cliConn,
 				nil,
@@ -785,7 +785,7 @@ var _ = Describe("Meta", func() {
 		cliConn.usernameErr = errors.New("some-error")
 
 		Expect(func() {
-			command.Meta(
+			cf.Meta(
 				context.Background(),
 				cliConn,
 				nil,
@@ -808,7 +808,7 @@ var _ = Describe("Meta", func() {
 		cliConn.cliCommandErr = nil
 
 		Expect(func() {
-			command.Meta(
+			cf.Meta(
 				context.Background(),
 				cliConn,
 				nil,
@@ -826,7 +826,7 @@ var _ = Describe("Meta", func() {
 		httpClient.responseErr = errors.New("some-error")
 
 		Expect(func() {
-			command.Meta(
+			cf.Meta(
 				context.Background(),
 				cliConn,
 				nil,

--- a/pkg/command/cf/tail.go
+++ b/pkg/command/cf/tail.go
@@ -1,4 +1,4 @@
-package command
+package cf
 
 import (
 	"context"

--- a/pkg/command/cf/tail_test.go
+++ b/pkg/command/cf/tail_test.go
@@ -1,4 +1,4 @@
-package command_test
+package cf_test
 
 import (
 	"context"
@@ -9,8 +9,7 @@ import (
 	"strconv"
 	"time"
 
-	"code.cloudfoundry.org/log-cache-cli/internal/command"
-
+	"code.cloudfoundry.org/log-cache-cli/pkg/command/cf"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -38,14 +37,14 @@ var _ = Describe("LogCache", func() {
 	})
 
 	It("removes headers when not printing to a tty", func() {
-		command.Tail(
+		cf.Tail(
 			context.Background(),
 			cliConn,
 			[]string{"app-name"},
 			httpClient,
 			logger,
 			writer,
-			command.WithTailNoHeaders(),
+			cf.WithTailNoHeaders(),
 		)
 
 		logFormat := "   %s [APP/PROC/WEB/0] %s log body"
@@ -67,7 +66,7 @@ var _ = Describe("LogCache", func() {
 		})
 
 		It("reports successful results", func() {
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				[]string{"app-name"},
@@ -102,7 +101,7 @@ var _ = Describe("LogCache", func() {
 			httpClient.responseBody = []string{
 				deprecatedTagsResponseBody(startTime),
 			}
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				[]string{"app-name"},
@@ -136,7 +135,7 @@ var _ = Describe("LogCache", func() {
 			httpClient.responseBody = []string{
 				counterResponseBody(startTime),
 			}
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				[]string{"app-name"},
@@ -168,7 +167,7 @@ var _ = Describe("LogCache", func() {
 			httpClient.responseBody = []string{
 				gaugeResponseBody(startTime),
 			}
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				[]string{"app-name"},
@@ -203,7 +202,7 @@ var _ = Describe("LogCache", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
 			defer cancel()
 
-			command.Tail(
+			cf.Tail(
 				ctx,
 				cliConn,
 				[]string{"app-name"},
@@ -238,7 +237,7 @@ var _ = Describe("LogCache", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
 			defer cancel()
 
-			command.Tail(
+			cf.Tail(
 				ctx,
 				cliConn,
 				[]string{"app-name"},
@@ -264,7 +263,7 @@ var _ = Describe("LogCache", func() {
 			defer cancel()
 
 			args := []string{"--envelope-type", "any", "--json", "app-name"}
-			command.Tail(
+			cf.Tail(
 				ctx,
 				cliConn,
 				args,
@@ -290,7 +289,7 @@ var _ = Describe("LogCache", func() {
 			defer cancel()
 
 			args := []string{"--type", "metrics", "--json", "app-name"}
-			command.Tail(
+			cf.Tail(
 				ctx,
 				cliConn,
 				args,
@@ -320,7 +319,7 @@ var _ = Describe("LogCache", func() {
 			defer cancel()
 
 			args := []string{"--type", "logs", "--json", "app-name"}
-			command.Tail(
+			cf.Tail(
 				ctx,
 				cliConn,
 				args,
@@ -350,7 +349,7 @@ var _ = Describe("LogCache", func() {
 
 			args := []string{"--gauge-name", "some-name", "--json", "app-name"}
 
-			command.Tail(
+			cf.Tail(
 				ctx,
 				cliConn,
 				args,
@@ -378,7 +377,7 @@ var _ = Describe("LogCache", func() {
 			defer cancel()
 
 			args := []string{"--counter-name", "some-name", "--json", "app-name"}
-			command.Tail(
+			cf.Tail(
 				ctx,
 				cliConn,
 				args,
@@ -411,7 +410,7 @@ var _ = Describe("LogCache", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
 			defer cancel()
 			now := time.Now()
-			command.Tail(
+			cf.Tail(
 				ctx,
 				cliConn,
 				[]string{"--follow", "app-name"},
@@ -475,7 +474,7 @@ var _ = Describe("LogCache", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
 			defer cancel()
 			now := time.Now()
-			command.Tail(
+			cf.Tail(
 				ctx,
 				cliConn,
 				[]string{"-f", "app-name"},
@@ -534,7 +533,7 @@ var _ = Describe("LogCache", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
 			defer cancel()
 			args := []string{"--counter-name", "some-name", "--json", "--follow", "app-name"}
-			command.Tail(
+			cf.Tail(
 				ctx,
 				cliConn,
 				args,
@@ -558,7 +557,7 @@ var _ = Describe("LogCache", func() {
 			os.Setenv("LOG_CACHE_ADDR", "https://different-log-cache:8080")
 			defer os.Unsetenv("LOG_CACHE_ADDR")
 
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				[]string{"app-name"},
@@ -578,7 +577,7 @@ var _ = Describe("LogCache", func() {
 			os.Setenv("LOG_CACHE_SKIP_AUTH", "true")
 			defer os.Unsetenv("LOG_CACHE_SKIP_AUTH")
 
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				[]string{"app-name"},
@@ -592,7 +591,7 @@ var _ = Describe("LogCache", func() {
 		It("follow retries for empty responses", func() {
 			httpClient.responseBody = []string{emptyResponseBody()}
 
-			go command.Tail(
+			go cf.Tail(
 				context.Background(),
 				cliConn,
 				[]string{"--follow", "app-name"},
@@ -608,7 +607,7 @@ var _ = Describe("LogCache", func() {
 			httpClient.responseBody = nil
 			httpClient.responseErr = errors.New("some-error")
 
-			go command.Tail(
+			go cf.Tail(
 				context.Background(),
 				cliConn,
 				[]string{"--follow", "app-name"},
@@ -624,7 +623,7 @@ var _ = Describe("LogCache", func() {
 			httpClient.responseBody = []string{
 				eventResponseBody(startTime),
 			}
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				[]string{"app-name"},
@@ -660,7 +659,7 @@ var _ = Describe("LogCache", func() {
 				"--lines", "99",
 				"app-name",
 			}
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				args,
@@ -687,7 +686,7 @@ var _ = Describe("LogCache", func() {
 				"-n", "99",
 				"app-name",
 			}
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				args,
@@ -706,7 +705,7 @@ var _ = Describe("LogCache", func() {
 			args := []string{
 				"app-name",
 			}
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				args,
@@ -723,7 +722,7 @@ var _ = Describe("LogCache", func() {
 
 		It("requests the app guid", func() {
 			args := []string{"some-app"}
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				args,
@@ -742,7 +741,7 @@ var _ = Describe("LogCache", func() {
 		It("places the auth token in the 'Authorization' header", func() {
 			args := []string{"some-app"}
 			cliConn.accessToken = "bearer some-token"
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				args,
@@ -763,7 +762,7 @@ var _ = Describe("LogCache", func() {
 				"app-guid",
 			}
 
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				args,
@@ -782,7 +781,7 @@ var _ = Describe("LogCache", func() {
 				"app-guid",
 			}
 
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				args,
@@ -797,7 +796,7 @@ var _ = Describe("LogCache", func() {
 		It("allows for empty end time with populated start time", func() {
 			args := []string{"--start-time", "1000", "app-name"}
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					args,
@@ -811,7 +810,7 @@ var _ = Describe("LogCache", func() {
 		It("fatally logs if envelope-type is invalid", func() {
 			args := []string{"--envelope-type", "invalid", "some-app"}
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					args,
@@ -831,7 +830,7 @@ var _ = Describe("LogCache", func() {
 				"some-app",
 			}
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					args,
@@ -853,7 +852,7 @@ var _ = Describe("LogCache", func() {
 			}
 
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					args,
@@ -873,7 +872,7 @@ var _ = Describe("LogCache", func() {
 				"some-app",
 			}
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					args,
@@ -893,7 +892,7 @@ var _ = Describe("LogCache", func() {
 				"some-app",
 			}
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					args,
@@ -915,7 +914,7 @@ var _ = Describe("LogCache", func() {
 			}
 
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					args,
@@ -931,7 +930,7 @@ var _ = Describe("LogCache", func() {
 		It("fatally logs if an output-format is malformed", func() {
 			args := []string{"--output-format", "{{INVALID}}", "app-guid"}
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					args,
@@ -952,7 +951,7 @@ var _ = Describe("LogCache", func() {
 			}
 
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					args,
@@ -971,7 +970,7 @@ var _ = Describe("LogCache", func() {
 				"some-app",
 			}
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					args,
@@ -990,7 +989,7 @@ var _ = Describe("LogCache", func() {
 				"some-app",
 			}
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					args,
@@ -1006,7 +1005,7 @@ var _ = Describe("LogCache", func() {
 			args := []string{"app-name"}
 
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					args,
@@ -1024,7 +1023,7 @@ var _ = Describe("LogCache", func() {
 			args := []string{"app-name"}
 
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					args,
@@ -1042,7 +1041,7 @@ var _ = Describe("LogCache", func() {
 			args := []string{"app-name"}
 
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					args,
@@ -1058,7 +1057,7 @@ var _ = Describe("LogCache", func() {
 		It("fatally logs if the start > end", func() {
 			args := []string{"--start-time", "1000", "--end-time", "100", "app-name"}
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					args,
@@ -1073,7 +1072,7 @@ var _ = Describe("LogCache", func() {
 
 		It("fatally logs if too many arguments are given", func() {
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					[]string{"one", "two"},
@@ -1088,7 +1087,7 @@ var _ = Describe("LogCache", func() {
 
 		It("fatally logs if not enough arguments are given", func() {
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					[]string{},
@@ -1105,7 +1104,7 @@ var _ = Describe("LogCache", func() {
 			cliConn.apiEndpointErr = errors.New("some-error")
 
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					[]string{"app-name"},
@@ -1122,7 +1121,7 @@ var _ = Describe("LogCache", func() {
 			cliConn.hasAPIEndpoint = false
 
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					[]string{"app-name"},
@@ -1140,7 +1139,7 @@ var _ = Describe("LogCache", func() {
 			cliConn.hasAPIEndpointErr = errors.New("some-error")
 
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					[]string{"app-name"},
@@ -1157,7 +1156,7 @@ var _ = Describe("LogCache", func() {
 			httpClient.responseErr = errors.New("some-error")
 
 			Expect(func() {
-				command.Tail(
+				cf.Tail(
 					context.Background(),
 					cliConn,
 					[]string{"app-name"},
@@ -1189,7 +1188,7 @@ var _ = Describe("LogCache", func() {
 				{"service-guid"},
 			}
 			args := []string{"service-name"}
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				args,
@@ -1217,7 +1216,7 @@ var _ = Describe("LogCache", func() {
 			cliConn.cliCommandErr = []error{errors.New("catch this instead")}
 
 			args := []string{"app-name"}
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				args,
@@ -1244,7 +1243,7 @@ var _ = Describe("LogCache", func() {
 
 		It("calls the log cache api", func() {
 			args := []string{"service-name"}
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				args,
@@ -1266,7 +1265,7 @@ var _ = Describe("LogCache", func() {
 
 		It("requests the service guid", func() {
 			args := []string{"some-service"}
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				args,
@@ -1295,7 +1294,7 @@ var _ = Describe("LogCache", func() {
 			cliConn.cliCommandErr = []error{errors.New("app not found"), errors.New("service not found")}
 
 			args := []string{"app-name"}
-			command.Tail(
+			cf.Tail(
 				context.Background(),
 				cliConn,
 				args,
@@ -1327,9 +1326,7 @@ var _ = Describe("LogCache", func() {
 			Expect(logger.printfMessages).To(ContainElement("app not found"))
 			Expect(logger.printfMessages).To(ContainElement("service not found"))
 		})
-
 	})
-
 })
 
 func responseBody(startTime time.Time) string {
@@ -1482,7 +1479,6 @@ var counterResponseTemplate = `{
 				"source_id": "app-name",
 				"instance_id":"0",
 				"timestamp":"%d",
-				"instance_id":"0",
 				"counter":{"name":"some-name","total":99}
 			}
 		]

--- a/pkg/command/command_suite_test.go
+++ b/pkg/command/command_suite_test.go
@@ -1,0 +1,75 @@
+package command_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"code.cloudfoundry.org/log-cache-cli/pkg/command"
+	homedir "github.com/mitchellh/go-homedir"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Command Suite")
+}
+
+func init() {
+	homedir.DisableCache = true
+}
+
+func patchEnv(key, value string) func() {
+	orig := os.Getenv(key)
+	err := os.Setenv(key, value)
+	Expect(err).ToNot(HaveOccurred())
+
+	return func() {
+		err := os.Setenv(key, orig)
+		Expect(err).ToNot(HaveOccurred())
+	}
+}
+
+func writeTmpConfig(c command.Config) func() {
+	dir, err := ioutil.TempDir("", "")
+	Expect(err).ToNot(HaveOccurred())
+
+	f, err := os.OpenFile(filepath.Join(dir, ".lc.yml"), os.O_RDWR|os.O_CREATE, 0755)
+	Expect(err).ToNot(HaveOccurred())
+	defer f.Close()
+	enc := yaml.NewEncoder(f)
+	err = enc.Encode(c)
+	Expect(err).ToNot(HaveOccurred())
+
+	origHome := os.Getenv("HOME")
+	err = os.Setenv("HOME", dir)
+	Expect(err).ToNot(HaveOccurred())
+
+	return func() {
+		err = os.Setenv("HOME", origHome)
+		Expect(err).ToNot(HaveOccurred())
+	}
+}
+
+func writeInvalidTmpConfig() func() {
+	dir, err := ioutil.TempDir("", "")
+	Expect(err).ToNot(HaveOccurred())
+
+	f, err := os.OpenFile(filepath.Join(dir, ".lc.yml"), os.O_RDWR|os.O_CREATE, 0755)
+	Expect(err).ToNot(HaveOccurred())
+	defer f.Close()
+	fmt.Fprint(f, "!@$^*!^!$)%@")
+
+	origHome := os.Getenv("HOME")
+	err = os.Setenv("HOME", dir)
+	Expect(err).ToNot(HaveOccurred())
+
+	return func() {
+		err = os.Setenv("HOME", origHome)
+		Expect(err).ToNot(HaveOccurred())
+	}
+}

--- a/pkg/command/config.go
+++ b/pkg/command/config.go
@@ -1,0 +1,46 @@
+package command
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	envstruct "code.cloudfoundry.org/go-envstruct"
+	homedir "github.com/mitchellh/go-homedir"
+	yaml "gopkg.in/yaml.v2"
+)
+
+type Config struct {
+	Addr     string `yaml:"addr" env:"LOG_CACHE_ADDR"`
+	SkipAuth bool   `yaml:"skip_auth" env:"LOG_CACHE_SKIP_AUTH"`
+}
+
+// BuildConfig reads in config file and ENV variables if set and returns a
+// config object.
+func BuildConfig() (Config, error) {
+	home, err := homedir.Dir()
+	if err != nil {
+		return Config{}, err
+	}
+
+	confPath := filepath.Join(home, ".lc.yml")
+	f, err := os.OpenFile(confPath, os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		return Config{}, err
+	}
+	defer f.Close()
+
+	dec := yaml.NewDecoder(f)
+	var conf Config
+	err = dec.Decode(&conf)
+	if err != nil && err != io.EOF {
+		return Config{}, err
+	}
+
+	err = envstruct.Load(&conf)
+	if err != nil {
+		return Config{}, err
+	}
+
+	return conf, nil
+}

--- a/pkg/command/config_test.go
+++ b/pkg/command/config_test.go
@@ -1,0 +1,103 @@
+package command_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"code.cloudfoundry.org/log-cache-cli/pkg/command"
+)
+
+var _ = Describe("Config", func() {
+	It("Loads config from file", func() {
+		expectedConfig := command.Config{
+			Addr: "test-file-addr",
+		}
+		cleanup := writeTmpConfig(expectedConfig)
+		defer cleanup()
+		cleanup = patchEnv("LOG_CACHE_ADDR", "")
+		defer cleanup()
+		cleanup = patchEnv("LOG_CACHE_SKIP_AUTH", "")
+		defer cleanup()
+
+		c, err := command.BuildConfig()
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(c).To(Equal(expectedConfig))
+	})
+
+	It("Loads config from env", func() {
+		expectedConfig := command.Config{
+			Addr: "test-env-addr",
+		}
+		cleanup := patchEnv("LOG_CACHE_ADDR", expectedConfig.Addr)
+		defer cleanup()
+		cleanup = patchEnv("LOG_CACHE_SKIP_AUTH", "")
+		defer cleanup()
+
+		c, err := command.BuildConfig()
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(c).To(Equal(expectedConfig))
+	})
+
+	It("Merges config file and env", func() {
+		expectedConfig := command.Config{
+			Addr:     "test-addr",
+			SkipAuth: true,
+		}
+		fileConfig := command.Config{
+			Addr: "test-addr",
+		}
+		cleanup := writeTmpConfig(fileConfig)
+		defer cleanup()
+		cleanup = patchEnv("LOG_CACHE_ADDR", "")
+		defer cleanup()
+		cleanup = patchEnv("LOG_CACHE_SKIP_AUTH", "true")
+		defer cleanup()
+
+		c, err := command.BuildConfig()
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(c).To(Equal(expectedConfig))
+	})
+
+	It("Prefers env over config file", func() {
+		fileConfig := command.Config{
+			Addr:     "some-bad-value",
+			SkipAuth: false,
+		}
+		expectedConfig := command.Config{
+			Addr:     "test-env-addr",
+			SkipAuth: true,
+		}
+		cleanup := writeTmpConfig(fileConfig)
+		defer cleanup()
+		cleanup = patchEnv("LOG_CACHE_ADDR", expectedConfig.Addr)
+		defer cleanup()
+		cleanup = patchEnv("LOG_CACHE_SKIP_AUTH", "true")
+		defer cleanup()
+
+		c, err := command.BuildConfig()
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(c).To(Equal(expectedConfig))
+	})
+
+	It("returns an error when home dir is not valid", func() {
+		cleanup := patchEnv("HOME", "/does/not/exist")
+		defer cleanup()
+
+		_, err := command.BuildConfig()
+
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns an error when config file is not valid yaml", func() {
+		cleanup := writeInvalidTmpConfig()
+		defer cleanup()
+
+		_, err := command.BuildConfig()
+
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/command/meta.go
+++ b/pkg/command/meta.go
@@ -71,6 +71,9 @@ func (m *Meta) runE(cmd *cobra.Command, args []string) error {
 		}
 		return err
 	}
+	if len(meta) == 0 {
+		return nil
+	}
 	rows := rows(meta)
 
 	headerArgs := []interface{}{"Source ID", "Count", "Expired", "Cache Duration"}

--- a/pkg/command/meta.go
+++ b/pkg/command/meta.go
@@ -1,0 +1,123 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"text/tabwriter"
+	"time"
+
+	logcache "code.cloudfoundry.org/go-log-cache"
+	"code.cloudfoundry.org/go-log-cache/rpc/logcache_v1"
+	"github.com/spf13/cobra"
+)
+
+type Meta struct {
+	*cobra.Command
+
+	conf      Config
+	timeout   time.Duration
+	noHeaders bool
+}
+
+type MetaOption func(*Meta)
+
+func WithMetaTimeout(d time.Duration) MetaOption {
+	return func(m *Meta) {
+		m.timeout = d
+	}
+}
+
+func WithMetaNoHeaders() MetaOption {
+	return func(m *Meta) {
+		m.noHeaders = true
+	}
+}
+
+func NewMeta(conf Config, opts ...MetaOption) *cobra.Command {
+	m := &Meta{
+		conf:    conf,
+		timeout: 2 * time.Second,
+	}
+	m.Command = m.command()
+
+	for _, o := range opts {
+		o(m)
+	}
+
+	return m.Command
+}
+
+func (m *Meta) command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "lc",
+		Short: "List cluster logs and metrics",
+		RunE:  m.runE,
+		Args:  cobra.NoArgs,
+	}
+	return cmd
+}
+
+func (m *Meta) runE(cmd *cobra.Command, args []string) error {
+	client := logcache.NewClient(m.conf.Addr)
+	ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
+	defer cancel()
+	meta, err := client.Meta(ctx)
+	if err != nil {
+		if err == io.EOF {
+			return nil
+		}
+		return err
+	}
+	rows := rows(meta)
+
+	headerArgs := []interface{}{"Source ID", "Count", "Expired", "Cache Duration"}
+	headerFormat := "%s\t%s\t%s\t%s\n"
+	rowFormat := "%s\t%d\t%d\t%s\n"
+
+	tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 2, 2, ' ', 0)
+	if !m.noHeaders {
+		fmt.Fprintf(tw, headerFormat, headerArgs...)
+	}
+
+	for _, r := range rows {
+		fmt.Fprintf(tw, rowFormat, r.SourceID, r.Count, r.Expired, r.Duration)
+	}
+
+	if err = tw.Flush(); err != nil {
+		return errors.New("Error writing results")
+	}
+
+	return nil
+}
+
+type row struct {
+	SourceID string
+	Count    int64
+	Expired  int64
+	Duration time.Duration
+}
+
+func rows(meta map[string]*logcache_v1.MetaInfo) []row {
+	rows := make([]row, 0, len(meta))
+	for k, v := range meta {
+		rows = append(rows, row{
+			SourceID: k,
+			Count:    v.Count,
+			Expired:  v.Expired,
+			Duration: cacheDuration(v),
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].SourceID < rows[j].SourceID
+	})
+	return rows
+}
+
+func cacheDuration(m *logcache_v1.MetaInfo) time.Duration {
+	new := time.Unix(0, m.NewestTimestamp)
+	old := time.Unix(0, m.OldestTimestamp)
+	return new.Sub(old).Truncate(time.Second)
+}

--- a/pkg/command/meta.go
+++ b/pkg/command/meta.go
@@ -52,7 +52,7 @@ func NewMeta(conf Config, opts ...MetaOption) *cobra.Command {
 
 func (m *Meta) command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "lc",
+		Use:   "log-cache",
 		Short: "List cluster logs and metrics",
 		RunE:  m.runE,
 		Args:  cobra.NoArgs,

--- a/pkg/command/meta_test.go
+++ b/pkg/command/meta_test.go
@@ -41,6 +41,24 @@ var _ = Describe("Meta", func() {
 		}))
 	})
 
+	It("doesn't print anything if there is no data", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, `{}`)
+		}))
+		defer server.Close()
+		var buf bytes.Buffer
+		metaCmd := command.NewMeta(command.Config{
+			Addr: server.URL,
+		})
+		metaCmd.SetOutput(&buf)
+		metaCmd.SetArgs([]string{})
+
+		err := metaCmd.Execute()
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buf.String()).To(BeEmpty())
+	})
+
 	It("removes header when not writing to a tty", func() {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, metaResponseInfo("source-id-5", "source-id-3", "source-id-4", "source-id-2"))

--- a/pkg/command/meta_test.go
+++ b/pkg/command/meta_test.go
@@ -99,18 +99,6 @@ var _ = Describe("Meta", func() {
 		Expect(buf.String()).To(BeEmpty())
 	})
 
-	It("returns an error if unable to retrieve meta info", func() {
-		metaCmd := command.NewMeta(command.Config{
-			Addr: "http://does-not-exist",
-		})
-		metaCmd.SetOutput(ioutil.Discard)
-		metaCmd.SetArgs([]string{})
-
-		err := metaCmd.Execute()
-
-		Expect(err).To(MatchError(ContainSubstring("no such host")))
-	})
-
 	It("timesout when server is taking too long", func() {
 		done := make(chan struct{})
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/command/meta_test.go
+++ b/pkg/command/meta_test.go
@@ -1,0 +1,133 @@
+package command_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"code.cloudfoundry.org/log-cache-cli/pkg/command"
+)
+
+var _ = Describe("Meta", func() {
+	It("prints source ids returned from the api in ascending order", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, metaResponseInfo("source-id-5", "source-id-3", "source-id-4", "source-id-2"))
+		}))
+		defer server.Close()
+		var buf bytes.Buffer
+		metaCmd := command.NewMeta(command.Config{
+			Addr: server.URL,
+		})
+		metaCmd.SetOutput(&buf)
+		metaCmd.SetArgs([]string{})
+
+		err := metaCmd.Execute()
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.Split(buf.String(), "\n")).To(Equal([]string{
+			"Source ID    Count   Expired  Cache Duration",
+			"source-id-2  100000  85008    11m45s",
+			"source-id-3  100000  85008    11m45s",
+			"source-id-4  100000  85008    11m45s",
+			"source-id-5  100000  85008    11m45s",
+			"",
+		}))
+	})
+
+	It("removes header when not writing to a tty", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, metaResponseInfo("source-id-5", "source-id-3", "source-id-4", "source-id-2"))
+		}))
+		defer server.Close()
+		var buf bytes.Buffer
+		metaCmd := command.NewMeta(command.Config{
+			Addr: server.URL,
+		}, command.WithMetaNoHeaders())
+		metaCmd.SetOutput(&buf)
+		metaCmd.SetArgs([]string{})
+
+		err := metaCmd.Execute()
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.Split(buf.String(), "\n")).To(Equal([]string{
+			"source-id-2  100000  85008  11m45s",
+			"source-id-3  100000  85008  11m45s",
+			"source-id-4  100000  85008  11m45s",
+			"source-id-5  100000  85008  11m45s",
+			"",
+		}))
+	})
+
+	It("doesn't return an error if the server responds with no data", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer server.Close()
+		metaCmd := command.NewMeta(command.Config{
+			Addr: server.URL,
+		})
+		var buf bytes.Buffer
+		metaCmd.SetOutput(&buf)
+		metaCmd.SetArgs([]string{})
+
+		err := metaCmd.Execute()
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buf.String()).To(BeEmpty())
+	})
+
+	It("returns an error if unable to retrieve meta info", func() {
+		metaCmd := command.NewMeta(command.Config{
+			Addr: "http://does-not-exist",
+		})
+		metaCmd.SetOutput(ioutil.Discard)
+		metaCmd.SetArgs([]string{})
+
+		err := metaCmd.Execute()
+
+		Expect(err).To(MatchError(ContainSubstring("no such host")))
+	})
+
+	It("timesout when server is taking too long", func() {
+		done := make(chan struct{})
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case <-time.After(time.Second):
+			case <-done:
+			}
+		}))
+		defer server.Close()
+		metaCmd := command.NewMeta(command.Config{
+			Addr: server.URL,
+		}, command.WithMetaTimeout(time.Nanosecond))
+		metaCmd.SetOutput(ioutil.Discard)
+		metaCmd.SetArgs([]string{})
+
+		var err error
+		go func() {
+			defer close(done)
+			err = metaCmd.Execute()
+		}()
+
+		Eventually(done, "500ms").Should(BeClosed())
+		Expect(err).To(MatchError(ContainSubstring("context deadline exceeded")))
+	})
+})
+
+func metaResponseInfo(sourceIDs ...string) string {
+	var metaInfos []string
+	for _, sourceID := range sourceIDs {
+		metaInfos = append(metaInfos, fmt.Sprintf(`"%s": {
+		  "count": "100000",
+		  "expired": "85008",
+		  "oldestTimestamp": "1519256157847077020",
+		  "newestTimestamp": "1519256863126668345"
+		}`, sourceID))
+	}
+	return fmt.Sprintf(`{ "meta": { %s }}`, strings.Join(metaInfos, ","))
+}

--- a/pkg/command/root.go
+++ b/pkg/command/root.go
@@ -1,0 +1,44 @@
+package command
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// Execute adds all child commands to the root command and sets flags
+// appropriately. This is called by main.main(). It only needs to happen once
+// to the rootCmd.
+func Execute(opts ...CommandOption) error {
+	c, err := BuildConfig()
+	if err != nil {
+		return err
+	}
+
+	isTerminal := terminal.IsTerminal(int(os.Stdout.Fd()))
+	var metaOpts []MetaOption
+	if !isTerminal {
+		metaOpts = append(metaOpts, WithMetaNoHeaders())
+	}
+
+	rootCmd := NewMeta(c)
+	rootCmd.AddCommand(NewTail(c))
+
+	for _, o := range opts {
+		o(rootCmd)
+	}
+	return rootCmd.Execute()
+}
+
+type Command interface {
+	SetOutput(io.Writer)
+}
+
+type CommandOption func(c Command)
+
+func WithOutput(out io.Writer) CommandOption {
+	return func(c Command) {
+		c.SetOutput(out)
+	}
+}

--- a/pkg/command/root_test.go
+++ b/pkg/command/root_test.go
@@ -1,0 +1,76 @@
+package command_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"code.cloudfoundry.org/log-cache-cli/pkg/command"
+)
+
+var _ = Describe("Execute", func() {
+	It("wires up the meta cmd", func() {
+		cleanup := patchArgs([]string{"--help"})
+		defer cleanup()
+		var buf bytes.Buffer
+
+		err := command.Execute(command.WithOutput(&buf))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buf.String()).To(ContainSubstring("List cluster logs and metrics"))
+	})
+
+	It("wires up tail cmd", func() {
+		cleanup := patchArgs([]string{"tail", "--help"})
+		defer cleanup()
+		var buf bytes.Buffer
+
+		err := command.Execute(command.WithOutput(&buf))
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(buf.String()).To(ContainSubstring("Output logs and metrics for a given source-id"))
+	})
+
+	It("runs meta by default", func() {
+		cleanup := patchArgs(nil)
+		defer cleanup()
+		paths := make(chan string, 100)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			paths <- r.URL.Path
+		}))
+		defer server.Close()
+		cleanup = patchEnv("LOG_CACHE_ADDR", server.URL)
+		defer cleanup()
+
+		err := command.Execute()
+
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(paths).Should(Receive(Equal("/v1/meta")))
+	})
+
+	It("returns an error if it can't build config", func() {
+		cleanup := patchEnv("HOME", "/does/not/exist")
+		defer cleanup()
+
+		err := command.Execute()
+
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
+	})
+})
+
+func patchArgs(args []string) func() {
+	orig := os.Args
+	new := make([]string, 0, len(args)+1)
+	new = append(new, orig[0])
+	new = append(new, args...)
+	os.Args = new
+
+	return func() {
+		os.Args = orig
+	}
+}

--- a/pkg/command/tail.go
+++ b/pkg/command/tail.go
@@ -1,0 +1,224 @@
+package command
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	logcache "code.cloudfoundry.org/go-log-cache"
+	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
+	"github.com/gogo/protobuf/proto"
+	"github.com/spf13/cobra"
+)
+
+type Tail struct {
+	*cobra.Command
+
+	conf      Config
+	noHeaders bool
+	timeout   time.Duration
+
+	follow bool
+}
+
+type TailOption func(*Tail)
+
+func WithTailNoHeaders() TailOption {
+	return func(t *Tail) {
+		t.noHeaders = true
+	}
+}
+
+func WithTailTimeout(d time.Duration) TailOption {
+	return func(t *Tail) {
+		t.timeout = d
+	}
+}
+
+func NewTail(conf Config, opts ...TailOption) *cobra.Command {
+	t := &Tail{
+		conf:    conf,
+		timeout: 5000 * time.Hour,
+	}
+	t.Command = t.command()
+
+	for _, o := range opts {
+		o(t)
+	}
+
+	return t.Command
+}
+
+func (t *Tail) command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tail <source-id>",
+		Short: "Output logs and metrics for a given source-id",
+		RunE:  t.runE,
+		Args:  cobra.ExactArgs(1),
+	}
+	cmd.Flags().BoolVarP(
+		&t.follow,
+		"follow",
+		"f",
+		false,
+		"Output appended to stdout as logs are egressed.",
+	)
+	return cmd
+}
+
+func (t *Tail) runE(_ *cobra.Command, args []string) error {
+	sourceID := args[0]
+
+	if !t.noHeaders {
+		header := fmt.Sprintf("Retrieving logs for %s...\n\n", sourceID)
+		fmt.Fprintf(t.OutOrStdout(), header)
+	}
+
+	client := logcache.NewClient(t.conf.Addr)
+	ctx, cancel := context.WithTimeout(context.Background(), t.timeout)
+	defer cancel()
+	if t.follow {
+		return t.walk(ctx, client, sourceID)
+	}
+	return t.read(ctx, client, sourceID)
+}
+
+func (t *Tail) walk(
+	ctx context.Context,
+	client *logcache.Client,
+	sourceID string,
+) error {
+	var err error
+	logcache.Walk(
+		ctx,
+		sourceID,
+		logcache.Visitor(func(envs []*loggregator_v2.Envelope) bool {
+			err = t.writeEnvs(envs)
+			if err != nil {
+				return false
+			}
+			return true
+		}),
+		client.Read,
+		logcache.WithWalkStartTime(time.Unix(0, 0)),
+		logcache.WithWalkBackoff(logcache.NewAlwaysRetryBackoff(250*time.Millisecond)),
+	)
+	return err
+}
+
+func (t *Tail) read(
+	ctx context.Context,
+	client *logcache.Client,
+	sourceID string,
+) error {
+	envs, err := client.Read(ctx, sourceID, time.Unix(0, 0))
+	if err != nil {
+		return err
+	}
+
+	return t.writeEnvs(envs)
+}
+
+func (t *Tail) writeEnvs(envs []*loggregator_v2.Envelope) error {
+	sort.Slice(envs, func(i, j int) bool {
+		return envs[i].GetTimestamp() < envs[j].GetTimestamp()
+	})
+
+	for _, e := range envs {
+		err := t.writeEnv(e)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *Tail) writeEnv(e *loggregator_v2.Envelope) error {
+	const timeFormat = "2006-01-02T15:04:05.00-0700"
+	ts := time.Unix(0, e.Timestamp)
+	var err error
+	switch e.Message.(type) {
+	case *loggregator_v2.Envelope_Log:
+		_, err = fmt.Fprintf(
+			t.OutOrStdout(),
+			"%s [%s/%s] LOG/%s %s\n",
+			ts.Format(timeFormat),
+			e.GetSourceId(),
+			e.GetInstanceId(),
+			e.GetLog().GetType(),
+			bytes.TrimRight(e.GetLog().GetPayload(), "\n"),
+		)
+	case *loggregator_v2.Envelope_Counter:
+		_, err = fmt.Fprintf(
+			t.OutOrStdout(),
+			"%s [%s/%s] COUNTER %s:%d\n",
+			ts.Format(timeFormat),
+			e.GetSourceId(),
+			e.GetInstanceId(),
+			e.GetCounter().GetName(),
+			e.GetCounter().GetTotal(),
+		)
+	case *loggregator_v2.Envelope_Gauge:
+		var values []string
+		for k, v := range e.GetGauge().GetMetrics() {
+			values = append(values, fmt.Sprintf("%s:%f %s", k, v.Value, v.Unit))
+		}
+
+		sort.Sort(sort.StringSlice(values))
+
+		_, err = fmt.Fprintf(
+			t.OutOrStdout(),
+			"%s [%s/%s] GAUGE %s\n",
+			ts.Format(timeFormat),
+			e.GetSourceId(),
+			e.GetInstanceId(),
+			strings.Join(values, " "),
+		)
+	case *loggregator_v2.Envelope_Timer:
+		_, err = fmt.Fprintf(
+			t.OutOrStdout(),
+			"%s [%s/%s] TIMER %s\n",
+			ts.Format(timeFormat),
+			e.GetSourceId(),
+			e.GetInstanceId(),
+			time.Unix(0, e.GetTimer().GetStop()).Sub(time.Unix(0, e.GetTimer().GetStart())),
+		)
+	case *loggregator_v2.Envelope_Event:
+		_, err = fmt.Fprintf(
+			t.OutOrStdout(),
+			"%s [%s/%s] EVENT %s:%s\n",
+			ts.Format(timeFormat),
+			e.GetSourceId(),
+			e.GetInstanceId(),
+			e.GetEvent().GetTitle(),
+			e.GetEvent().GetBody(),
+		)
+	default:
+		ec, ok := proto.Clone(e).(*loggregator_v2.Envelope)
+		if ok {
+			// Zero out fields that are already displayed in the message
+			// format.
+			ec.Timestamp = 0
+			ec.SourceId = ""
+			ec.InstanceId = ""
+		} else {
+			// We are not going to cover this. The type assertion should
+			// always be ok. If it is not it isn't the end of the world. Just
+			// fall back to displaying the whole envelope.
+			ec = e
+		}
+		_, err = fmt.Fprintf(
+			t.OutOrStdout(),
+			"%s [%s/%s] UNKNOWN %s\n",
+			ts.Format(timeFormat),
+			e.GetSourceId(),
+			e.GetInstanceId(),
+			strings.TrimSpace(ec.String()),
+		)
+	}
+
+	return err
+}

--- a/pkg/command/tail_test.go
+++ b/pkg/command/tail_test.go
@@ -89,18 +89,6 @@ var _ = Describe("Tail", func() {
 		Entry("too many args", []string{"foo", "bar"}),
 	)
 
-	It("returns an error when read fails", func() {
-		tailCmd := command.NewTail(command.Config{
-			Addr: "http://does-not-exist",
-		})
-		tailCmd.SetOutput(ioutil.Discard)
-		tailCmd.SetArgs([]string{"test-source-id"})
-
-		err := tailCmd.Execute()
-
-		Expect(err).To(MatchError(ContainSubstring("no such host")))
-	})
-
 	It("timesout when server is taking too long", func() {
 		done := make(chan struct{})
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/command/tail_test.go
+++ b/pkg/command/tail_test.go
@@ -1,0 +1,491 @@
+package command_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"code.cloudfoundry.org/log-cache-cli/pkg/command"
+)
+
+var _ = Describe("Tail", func() {
+	It("writes results from server", func() {
+		paths := make(chan string, 100)
+		startTimes := make(chan string, 100)
+
+		startTime := time.Now()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			paths <- r.URL.Path
+			startTimes <- r.URL.Query().Get("start_time")
+			fmt.Fprint(w, tailResponseBodyDesc(startTime))
+		}))
+		defer server.Close()
+		var buf bytes.Buffer
+		tailCmd := command.NewTail(command.Config{
+			Addr: server.URL,
+		})
+		tailCmd.SetOutput(&buf)
+		tailCmd.SetArgs([]string{"test-source-id"})
+
+		err := tailCmd.Execute()
+
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(paths).Should(Receive(Equal("/v1/read/test-source-id")))
+		Eventually(startTimes).Should(Receive(Or(Equal(""), Equal("0"))))
+		Expect(strings.Split(buf.String(), "\n")).To(Equal([]string{
+			"Retrieving logs for test-source-id...",
+			"",
+			fmt.Sprintf(logFormat, startTime.Format(timeFormat), "ERR"),
+			fmt.Sprintf(logFormat, startTime.Add(1*time.Second).Format(timeFormat), "OUT"),
+			fmt.Sprintf(logFormat, startTime.Add(2*time.Second).Format(timeFormat), "OUT"),
+			"",
+		}))
+	})
+
+	It("removes headers when not printing to a tty", func() {
+		startTime := time.Now()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, tailResponseBodyDesc(startTime))
+		}))
+		defer server.Close()
+		var buf bytes.Buffer
+		tailCmd := command.NewTail(command.Config{
+			Addr: server.URL,
+		}, command.WithTailNoHeaders())
+		tailCmd.SetOutput(&buf)
+		tailCmd.SetArgs([]string{"test-source-id"})
+
+		err := tailCmd.Execute()
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.Split(buf.String(), "\n")).To(Equal([]string{
+			fmt.Sprintf(logFormat, startTime.Format(timeFormat), "ERR"),
+			fmt.Sprintf(logFormat, startTime.Add(1*time.Second).Format(timeFormat), "OUT"),
+			fmt.Sprintf(logFormat, startTime.Add(2*time.Second).Format(timeFormat), "OUT"),
+			"",
+		}))
+	})
+
+	DescribeTable("returns an error if args are not correct", func(args []string) {
+		tailCmd := command.NewTail(command.Config{})
+		tailCmd.SetOutput(ioutil.Discard)
+		tailCmd.SetArgs(args)
+
+		err := tailCmd.Execute()
+
+		Expect(err).To(HaveOccurred())
+	},
+		Entry("no source id", nil),
+		Entry("too many args", []string{"foo", "bar"}),
+	)
+
+	It("returns an error when read fails", func() {
+		tailCmd := command.NewTail(command.Config{
+			Addr: "http://does-not-exist",
+		})
+		tailCmd.SetOutput(ioutil.Discard)
+		tailCmd.SetArgs([]string{"test-source-id"})
+
+		err := tailCmd.Execute()
+
+		Expect(err).To(MatchError(ContainSubstring("no such host")))
+	})
+
+	It("timesout when server is taking too long", func() {
+		done := make(chan struct{})
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case <-time.After(time.Second):
+			case <-done:
+			}
+		}))
+		defer server.Close()
+		tailCmd := command.NewTail(command.Config{
+			Addr: server.URL,
+		}, command.WithTailTimeout(time.Nanosecond))
+		tailCmd.SetOutput(ioutil.Discard)
+		tailCmd.SetArgs([]string{"test-source-id"})
+
+		var err error
+		go func() {
+			defer close(done)
+			err = tailCmd.Execute()
+		}()
+
+		Eventually(done, "500ms").Should(BeClosed())
+		Expect(err).To(MatchError(ContainSubstring("context deadline exceeded")))
+	})
+
+	DescribeTable("displays all event types", func(resp, result string) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, resp)
+		}))
+		defer server.Close()
+		var buf bytes.Buffer
+		tailCmd := command.NewTail(command.Config{
+			Addr: server.URL,
+		}, command.WithTailNoHeaders())
+		tailCmd.SetOutput(&buf)
+		tailCmd.SetArgs([]string{"test-source-id"})
+
+		err := tailCmd.Execute()
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.Split(buf.String(), "\n")).To(Equal([]string{
+			result,
+			"",
+		}))
+	},
+		Entry(
+			"log",
+			logResponseBody(time.Unix(0, 1)),
+			fmt.Sprintf(logFormat, time.Unix(0, 1).Format(timeFormat), "OUT"),
+		),
+		Entry(
+			"counter",
+			counterResponseBody(time.Unix(0, 1)),
+			fmt.Sprintf(
+				counterFormat,
+				time.Unix(0, 1).Format(timeFormat),
+				"some-name",
+				99,
+			),
+		),
+		Entry(
+			"gauge",
+			gaugeResponseBody(time.Unix(0, 1)),
+			fmt.Sprintf(
+				gaugeFormat,
+				time.Unix(0, 1).Format(timeFormat),
+				"some-name",
+				99.0,
+				"my-unit",
+				"some-other-name",
+				101.0,
+				"my-unit",
+			),
+		),
+		Entry(
+			"timer",
+			timerResponseBody(time.Unix(0, 1)),
+			fmt.Sprintf(
+				timerFormat,
+				time.Unix(0, 1).Format(timeFormat),
+				"1s",
+			),
+		),
+		Entry(
+			"event",
+			eventResponseBody(time.Unix(0, 1)),
+			fmt.Sprintf(
+				eventFormat,
+				time.Unix(0, 1).Format(timeFormat),
+				"some-title",
+				"some-body",
+			),
+		),
+		Entry(
+			"unknown",
+			unknownResponseBody(time.Unix(0, 1)),
+			fmt.Sprintf(
+				unknownFormat,
+				time.Unix(0, 1).Format(timeFormat),
+				`tags:<key:"foo" value:"bar" >`,
+			),
+		),
+	)
+
+	Describe("--follow", func() {
+		It("streams data when follow flag is provided", func() {
+			startTime := time.Now().Add(-1 * time.Minute)
+			handler := newIncrementalHandler(
+				tailResponseBodyDesc(startTime.Add(-30*time.Second)),
+				tailResponseBodyAsc(startTime),
+				tailResponseBodyAsc(startTime.Add(3*time.Second)),
+			)
+			server := httptest.NewServer(handler)
+			defer server.Close()
+			tailCmd := command.NewTail(command.Config{
+				Addr: server.URL,
+			}, command.WithTailTimeout(250*time.Millisecond))
+			var buf bytes.Buffer
+			tailCmd.SetArgs([]string{"--follow", "test-source-id"})
+			tailCmd.SetOutput(&buf)
+
+			err := tailCmd.Execute()
+
+			Expect(err).ToNot(HaveOccurred())
+			startTimeParam := handler.requests()[0].URL.Query().Get("start_time")
+			Expect(startTimeParam).To(Or(Equal(""), Equal("0")))
+			Expect(strings.Split(buf.String(), "\n")).To(ConsistOf(
+				"Retrieving logs for test-source-id...",
+				"",
+				fmt.Sprintf(logFormat, startTime.Add(-30*time.Second).Format(timeFormat), "ERR"),
+				fmt.Sprintf(logFormat, startTime.Add(-29*time.Second).Format(timeFormat), "OUT"),
+				fmt.Sprintf(logFormat, startTime.Add(-28*time.Second).Format(timeFormat), "OUT"),
+				fmt.Sprintf(logFormat, startTime.Format(timeFormat), "OUT"),
+				fmt.Sprintf(logFormat, startTime.Add(1*time.Second).Format(timeFormat), "OUT"),
+				fmt.Sprintf(logFormat, startTime.Add(2*time.Second).Format(timeFormat), "ERR"),
+				fmt.Sprintf(logFormat, startTime.Add(3*time.Second).Format(timeFormat), "OUT"),
+				fmt.Sprintf(logFormat, startTime.Add(4*time.Second).Format(timeFormat), "OUT"),
+				fmt.Sprintf(logFormat, startTime.Add(5*time.Second).Format(timeFormat), "ERR"),
+				"",
+			))
+		})
+
+		It("returns an error when it can't write to output", func() {
+			startTime := time.Now().Add(-1 * time.Minute)
+			handler := newIncrementalHandler(
+				tailResponseBodyAsc(startTime),
+			)
+			server := httptest.NewServer(handler)
+			defer server.Close()
+			tailCmd := command.NewTail(command.Config{
+				Addr: server.URL,
+			}, command.WithTailTimeout(250*time.Millisecond))
+			tailCmd.SetArgs([]string{"--follow", "test-source-id"})
+			tailCmd.SetOutput(errWriter{})
+
+			err := tailCmd.Execute()
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+const (
+	logFormat     = "%s [app-name/0] LOG/%s log body"
+	counterFormat = "%s [app-name/0] COUNTER %s:%d"
+	gaugeFormat   = "%s [app-name/0] GAUGE %s:%f %s %s:%f %s"
+	timerFormat   = "%s [app-name/0] TIMER %s"
+	eventFormat   = "%s [app-name/0] EVENT %s:%s"
+	unknownFormat = "%s [app-name/0] UNKNOWN %s"
+	timeFormat    = "2006-01-02T15:04:05.00-0700"
+
+	responseTemplate = `{
+		"envelopes": {
+			"batch": [
+				{
+					"source_id": "app-name",
+					"instance_id":"0",
+					"timestamp":"%d",
+					"log":{
+						"payload":"bG9nIGJvZHkK"
+					}
+				},
+				{
+					"source_id": "app-name",
+					"instance_id":"0",
+					"timestamp":"%d",
+					"log":{
+						"payload":"bG9nIGJvZHkK"
+					}
+				},
+				{
+					"source_id": "app-name",
+					"instance_id":"0",
+					"timestamp":"%d",
+					"log":{
+						"payload":"bG9nIGJvZHkK",
+						"type": "ERR"
+					}
+				}
+			]
+		}
+	}`
+
+	logResponseTemplate = `{
+		"envelopes": {
+			"batch": [
+				{
+					"source_id": "app-name",
+					"instance_id":"0",
+					"timestamp":"%d",
+					"log":{
+						"payload":"bG9nIGJvZHkK"
+					}
+				}
+			]
+		}
+	}`
+
+	counterResponseTemplate = `{
+		"envelopes": {
+			"batch": [
+				{
+					"source_id": "app-name",
+					"instance_id":"0",
+					"timestamp":"%d",
+					"counter":{"name":"some-name","total":99}
+				}
+			]
+		}
+	}`
+
+	gaugeResponseTemplate = `{
+		"envelopes": {
+			"batch": [
+				{
+					"source_id": "app-name",
+					"instance_id":"0",
+					"timestamp": "%d",
+					"gauge": {
+					  "metrics": {
+						"some-name": {
+						  "value": 99,
+						  "unit":"my-unit"
+						},
+						"some-other-name": {
+						  "value": 101,
+						  "unit":"my-unit"
+						}
+					  }
+					}
+				  }
+			]
+		}
+	}`
+
+	timerResponseTemplate = `{
+		"envelopes": {
+			"batch": [
+				{
+					"source_id": "app-name",
+					"timestamp": "%d",
+					"instance_id":"0",
+					"timer": {
+						"name": "http",
+						"start": "%d",
+						"stop": "%d"
+					}
+				}
+			]
+		}
+	}`
+
+	eventResponseTemplate = `{
+		"envelopes": {
+			"batch": [
+				{
+					"source_id": "app-name",
+					"instance_id":"0",
+					"timestamp": "%d",
+					"event": {
+						"title": "some-title",
+						"body": "some-body"
+					}
+				}
+			]
+		}
+	}`
+
+	unknownResponseTemplate = `{
+		"envelopes": {
+			"batch": [
+				{
+					"source_id": "app-name",
+					"instance_id":"0",
+					"timestamp": "%d",
+					"tags": {"foo":"bar"}
+				}
+			]
+		}
+	}`
+)
+
+func tailResponseBodyDesc(startTime time.Time) string {
+	// NOTE: These are in descending order.
+	return fmt.Sprintf(responseTemplate,
+		startTime.Add(2*time.Second).UnixNano(),
+		startTime.Add(1*time.Second).UnixNano(),
+		startTime.UnixNano(),
+	)
+}
+
+func tailResponseBodyAsc(startTime time.Time) string {
+	// NOTE: These are in ascending order.
+	return fmt.Sprintf(responseTemplate,
+		startTime.UnixNano(),
+		startTime.Add(1*time.Second).UnixNano(),
+		startTime.Add(2*time.Second).UnixNano(),
+	)
+}
+
+func logResponseBody(startTime time.Time) string {
+	return fmt.Sprintf(logResponseTemplate, startTime.UnixNano())
+}
+
+func counterResponseBody(startTime time.Time) string {
+	return fmt.Sprintf(counterResponseTemplate, startTime.UnixNano())
+}
+
+func gaugeResponseBody(startTime time.Time) string {
+	return fmt.Sprintf(gaugeResponseTemplate, startTime.UnixNano())
+}
+
+func timerResponseBody(startTime time.Time) string {
+	return fmt.Sprintf(
+		timerResponseTemplate,
+		startTime.UnixNano(),
+		startTime.Add(1*time.Second).UnixNano(),
+		startTime.Add(2*time.Second).UnixNano(),
+	)
+}
+
+func eventResponseBody(startTime time.Time) string {
+	return fmt.Sprintf(
+		eventResponseTemplate,
+		startTime.UnixNano(),
+	)
+}
+
+func unknownResponseBody(startTime time.Time) string {
+	return fmt.Sprintf(unknownResponseTemplate, startTime.UnixNano())
+}
+
+type incrementalHandler struct {
+	mu        sync.Mutex
+	count     int
+	reqs      []*http.Request
+	responses []string
+}
+
+func newIncrementalHandler(responses ...string) *incrementalHandler {
+	return &incrementalHandler{
+		responses: responses,
+	}
+}
+
+func (i *incrementalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var resp string
+	i.mu.Lock()
+	if i.count < len(i.responses) {
+		resp = i.responses[i.count]
+	}
+	i.count++
+	i.reqs = append(i.reqs, r)
+	i.mu.Unlock()
+	fmt.Fprint(w, resp)
+}
+
+func (i *incrementalHandler) requests() []*http.Request {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.reqs
+}
+
+type errWriter struct{}
+
+func (e errWriter) Write(p []byte) (n int, err error) {
+	return 0, errors.New("i am error")
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+owner=cloudfoundry
+repo=log-cache-cli
+binary="$(uname | tr 'A-Z' 'a-z')"
+
+if [ "$binary" != "linux" ] && [ "$binary" != "darwin" ]; then
+  echo "Error: Unable to detect platform. Installation script currently works \
+        for Linux and OSX platforms."
+  exit 1
+fi
+
+latest_release_id="$(
+    curl -s "https://api.github.com/repos/$owner/$repo/releases/latest" | \
+        python -c 'import sys, json; print(json.load(sys.stdin).get("id", ""))'
+)"
+assets_json="$(
+    curl -s "https://api.github.com/repos/$owner/$repo/releases/$latest_release_id/assets"
+)"
+asset_id="$(
+    echo "$assets_json " \
+        | python -c 'import sys, json; print([x for x in json.load(sys.stdin) if "'"$binary"'" in x.get("name", "")][0].get("id", ""))'
+)"
+asset_name="$(
+    echo "$assets_json " \
+        | python -c 'import sys, json; print([x for x in json.load(sys.stdin) if "'"$binary"'" in x.get("name", "")][0].get("name", ""))'
+)"
+
+echo "Downloading $asset_name from $owner/$repo..."
+curl -sL "https://api.github.com/repos/$owner/$repo/releases/assets/$asset_id" \
+    -H "Accept: application/octet-stream" -o "$asset_name"
+
+chmod +x "$asset_name"
+# test if we can write to destintaion
+(if >> /usr/local/bin/lc; then
+    mv "$asset_name" /usr/local/bin/lc
+else
+    sudo mv "$asset_name" /usr/local/bin/lc
+fi) > /dev/null 2>&1
+
+read -r -p 'Did you want to create the shortcut "log-cache" for the "lc" CLI? [y/N]: ' create_shortcut
+if [[ "$create_shortcut" =~ ^[Yy]$ ]]; then
+    # test if we can write to destintaion
+    (if >> /usr/local/bin/log-cache; then
+        rm -f /usr/local/bin/log-cache
+        ln -s /usr/local/bin/lc /usr/local/bin/log-cache
+    else
+        sudo ln -s /usr/local/bin/lc /usr/local/bin/log-cache
+    fi) > /dev/null 2>&1
+fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+read -r -p "Are you sure you want to remove the log-cache CLI? [y/N]: " remove_cli
+if [[ ! "$remove_cli" =~ ^[Yy]$ ]]; then
+    exit 0
+fi
+
+rm -f /usr/local/bin/lc
+rm -f /usr/local/bin/log-cache


### PR DESCRIPTION
- Reorganize project structure to support multiple CLIs
- Move cf commands into their own package
- Implement lc CLI meta functionality
- Implement basic tail functionality
- Load config for CLI from home dir
- Remove headers when piping into another command
- Prevent config tests for being affected by outside env vars

[#157012365 #157011068]

Signed-off-by: Warren Fernandes <wfernandes@pivotal.io>