### PR TITLE
Allow tail command to replace a char with newline

### DIFF
--- a/pkg/command/cf/tail.go
+++ b/pkg/command/cf/tail.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/template"
 	"time"
+	"unicode/utf8"
 
 	"code.cloudfoundry.org/cli/plugin"
 	logcache "code.cloudfoundry.org/go-log-cache"
@@ -65,7 +66,7 @@ func Tail(
 	}
 
 	sourceID := o.guid
-	formatter := newFormatter(o.providedName, o.follow, formatterKindFromOptions(o), log, o.outputTemplate)
+	formatter := newFormatter(o.providedName, o.follow, formatterKindFromOptions(o), log, o.outputTemplate, o.newLineReplacer)
 	lw := lineWriter{w: w}
 
 	defer func() {
@@ -241,7 +242,8 @@ type options struct {
 	gaugeName   string
 	counterName string
 
-	noHeaders bool
+	noHeaders       bool
+	newLineReplacer rune
 }
 
 type optionFlags struct {
@@ -255,6 +257,7 @@ type optionFlags struct {
 	GaugeName     string `long:"gauge-name"`
 	CounterName   string `long:"counter-name"`
 	EnvelopeClass string `long:"type"`
+	NewLine       string `long:"new-line" optional:"true" optional-value:"\\u2028"`
 }
 
 func newOptions(cli plugin.CliConnection, args []string, log Logger) (options, error) {
@@ -318,6 +321,13 @@ func newOptions(cli plugin.CliConnection, args []string, log Logger) (options, e
 		gaugeName:      opts.GaugeName,
 		counterName:    opts.CounterName,
 		envelopeClass:  toEnvelopeClass(opts.EnvelopeClass),
+	}
+
+	if opts.NewLine != "" {
+		o.newLineReplacer, err = parseNewLineArgument(opts.NewLine)
+		if err != nil {
+			log.Fatalf("%s", err)
+		}
 	}
 
 	return o, o.validate()
@@ -467,6 +477,30 @@ func getServiceGUID(serviceName string, cli plugin.CliConnection, log Logger) st
 	}
 
 	return strings.Join(r, "")
+}
+
+func parseNewLineArgument(s string) (rune, error) {
+	if strings.TrimSpace(s) == "" {
+		return '\u2028', nil
+	}
+
+	if utf8.RuneCountInString(s) == 1 {
+		r, _ := utf8.DecodeRuneInString(s)
+		return r, nil
+	}
+
+	s = strings.ToLower(s)
+	if strings.HasPrefix(s, "\\u") {
+		var r rune
+		_, err := fmt.Sscanf(s, "\\u%x", &r)
+		if err != nil {
+			return 0, err
+		}
+
+		return r, nil
+	}
+
+	return 0, errors.New("--new-line argument must be single unicode character or in the format \\uXXXXX")
 }
 
 type backoff struct {


### PR DESCRIPTION
## Problem Statement
Because metron (rightfully) treats each line as an individual message, certain conditions (say, a Java stacktrace) generate a single, _n_-line message that metron treats as _n_ 1-line messages. This makes searching in a logging storage solution like ELK or Splunk non-trivially difficult. 

In this case, there is a very simple solution: tell your application to log multiline messages with some arbitrary (usually non-printable) character in place of `\n`. This is usually the unicode NEWLINE codepoint, `U+2028`.

However, when this is done, reading "directly" from the loggregator system (via `cf logs` or `cf tail`) results in hard-to-read messages, as the non-printable character is not translated back to `\n`.

## Proposed solution

After discussing with @colins, I have added a new, optional argument to `cf tail` called `--new-line`. When set, it will translate the unicode character back to `\n` in the display. The behavior is thus:
```
cf tail  # nothing changes 
cf tail --new-line # will render all instances of \u2028 as \n in output
cf tail --new-line=\u1234 #will render all instances of \u1234 as \n in output
cf tail --new-line=🎶 # will render all instances of 🎶 as \n in output
cf tail --newline=hello # fails
```