### PR TITLE
golangci-lint: ignore specific instance of G402 rather than all instances

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,10 +12,6 @@ linters-settings:
     # Minimal code complexity to report.
     # https://github.com/fzipp/gocyclo#readme
     min-complexity: 28
-  gosec:
-    excludes:
-      # Ignore the fact that we might set TLS InsecureSkipVerify
-      - G402
 issues:
   # Disable max issues per linter.
   max-issues-per-linter: 0

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func (c *LogCacheCLI) Run(conn plugin.CliConnection, args []string) {
 		log.Fatal(err)
 	}
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
-		InsecureSkipVerify: skipSSL,
+		InsecureSkipVerify: skipSSL, //nolint:gosec
 	}
 
 	l := log.New(os.Stderr, "", 0)


### PR DESCRIPTION
# Description

Having the exclude for gosec in `.golangci.yml` meant that linter would
never check for that error. Instead we should just skip the particular
instance of the error that we want to ignore.

## Type of change

- [x] General update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

