### PR TITLE
json encoding no longer causes logs to display in base64 format

### DIFF
--- a/internal/command/tail_test.go
+++ b/internal/command/tail_test.go
@@ -283,7 +283,7 @@ var _ = Describe("LogCache", func() {
 				{"timestamp":"%d","source_id":"app-name","instance_id":"0","timer":{"name":"http","start":"1517940773000000000","stop":"1517940773000000000"}},
 				{"timestamp":"%d","source_id":"app-name","instance_id":"0","gauge":{"metrics":{"some-name":{"unit":"my-unit","value":99}}}},
 				{"timestamp":"%d","source_id":"app-name","instance_id":"0","counter":{"name":"some-name","total":"99"}},
-				{"timestamp":"%d","source_id":"app-name","instance_id":"0","tags":{"source_type":"APP/PROC/WEB"},"log":{"payload":"bG9nIGJvZHk="}}
+				{"timestamp":"%d","source_id":"app-name","instance_id":"0","tags":{"source_type":"APP/PROC/WEB"},"log":{"payload":"log body"}}
 			]}`, startTime.UnixNano(), startTime.UnixNano(), startTime.UnixNano(), startTime.UnixNano(), startTime.UnixNano())))
 		})
 
@@ -336,7 +336,7 @@ var _ = Describe("LogCache", func() {
 
 			Expect(writer.bytes).To(MatchJSON(fmt.Sprintf(`{"batch":[
 				{"timestamp":"%d","source_id":"app-name","instance_id":"0","event":{"title":"some-title","body":"some-body"}},
-				{"timestamp":"%d","source_id":"app-name","instance_id":"0","tags":{"source_type":"APP/PROC/WEB"},"log":{"payload":"bG9nIGJvZHk="}}
+				{"timestamp":"%d","source_id":"app-name","instance_id":"0","tags":{"source_type":"APP/PROC/WEB"},"log":{"payload":"log body"}}
 			]}`, startTime.UnixNano(), startTime.UnixNano())))
 
 			Expect(httpClient.requestURLs).ToNot(BeEmpty())


### PR DESCRIPTION
# Description

Please include a summary of the change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [?] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [x] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
