### PR TITLE
fix(go.mod): Update go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module code.cloudfoundry.org/log-cache-cli/v4
 
-go 1.22.0
+go 1.22
+
+toolchain go1.22.8
 
 require (
 	code.cloudfoundry.org/cli v7.1.0+incompatible


### PR DESCRIPTION
Uses `1.22` as the `go` version and `go1.22.8` as the toolchain version. This should fix GH actions, enabling it to select and use the latest patch version of go1.22 rather than go1.22.0 every time.