### PR TITLE
CAPI call migration from  v2 to v3

### DIFF
--- a/internal/command/meta.go
+++ b/internal/command/meta.go
@@ -442,7 +442,7 @@ func getSourceInfo(metaInfo map[string]*logcache_v1.MetaInfo, cli plugin.CliConn
 		s = append(s, id)
 	}
 
-	serviceInfo, err := getSourceInfoFromCAPI(s, "/v2/service_instances", cli)
+	serviceInfo, err := getSourceInfoFromCAPI(s, "/v3/service_instances", cli)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/meta_test.go
+++ b/internal/command/meta_test.go
@@ -579,7 +579,7 @@ var _ = Describe("Meta", func() {
 
 		Expect(cliConn.cliCommandArgs[1]).To(HaveLen(2))
 		Expect(cliConn.cliCommandArgs[1][0]).To(Equal("curl"))
-		Expect(cliConn.cliCommandArgs[1][1]).To(Equal("/v2/service_instances?guids=source-2"))
+		Expect(cliConn.cliCommandArgs[1][1]).To(Equal("/v3/service_instances?guids=source-2"))
 
 		Expect(httpClient.requestCount()).To(Equal(1))
 		Expect(strings.Split(tableWriter.String(), "\n")).To(Equal([]string{
@@ -1002,14 +1002,14 @@ var _ = Describe("Meta", func() {
 		Expect(cliConn.cliCommandArgs[2][0]).To(Equal("curl"))
 		uri, err = url.Parse(cliConn.cliCommandArgs[2][1])
 		Expect(err).ToNot(HaveOccurred())
-		Expect(uri.Path).To(Equal("/v2/service_instances"))
+		Expect(uri.Path).To(Equal("/v3/service_instances"))
 		Expect(strings.Split(uri.Query().Get("guids"), ",")).To(HaveLen(50))
 
 		Expect(cliConn.cliCommandArgs[3]).To(HaveLen(2))
 		Expect(cliConn.cliCommandArgs[3][0]).To(Equal("curl"))
 		uri, err = url.Parse(cliConn.cliCommandArgs[3][1])
 		Expect(err).ToNot(HaveOccurred())
-		Expect(uri.Path).To(Equal("/v2/service_instances"))
+		Expect(uri.Path).To(Equal("/v3/service_instances"))
 		Expect(strings.Split(uri.Query().Get("guids"), ",")).To(HaveLen(1))
 
 		// 51 entries, 2 blank lines, "Retrieving..." preamble and table


### PR DESCRIPTION
# Description

The CAPI v2 is deprecated and will be removed in the cf-deployment. Therefore an update is needed to use the newer CAPI v3.

Fixes #275

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [x] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes