### PR TITLE
chore: Bump minimum go version to go1.23.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module code.cloudfoundry.org/log-cache-cli/v4
 
-go 1.22
-toolchain go1.22.8
+go 1.23.4
 
 require (
 	code.cloudfoundry.org/cli v7.1.0+incompatible


### PR DESCRIPTION
# Description

Bumps the minimum version of Go allowed to test and compile this module to go1.23.4.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [x] Integration tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
