### PR TITLE
feat: Bump module to Go 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module code.cloudfoundry.org/log-cache-cli/v4
 
-go 1.22
-toolchain go1.22.8
+go 1.23
+
+toolchain go1.23.4
 
 require (
 	code.cloudfoundry.org/cli v7.1.0+incompatible


### PR DESCRIPTION
# Description

* Requires go1.23.
* Sets toolchain to latest go1.23 version, which is go1.23.4.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [x] Integration tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [x] I have added testing for my changes