### PR TITLE
ci(release): Remove old win32 binary that is likely unused

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
           GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=$VERSION" -o "bin/log-cache-cf-plugin_${VERSION}_linux_arm64"
           GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version=$VERSION" -o "bin/log-cache-cf-plugin_${VERSION}_darwin_amd64"
           GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.version=$VERSION" -o "bin/log-cache-cf-plugin_${VERSION}_darwin_arm64"
-          GOOS=windows GOARCH=386 go build -ldflags "-X main.version=$VERSION" -o "bin/log-cache-cf-plugin_${VERSION}_windows_386.exe"
           GOOS=windows GOARCH=amd64 go build -ldflags "-X main.version=$VERSION" -o "bin/log-cache-cf-plugin_${VERSION}_windows_amd64.exe"
         env:
           VERSION: ${{ github.event.inputs.version }}


### PR DESCRIPTION
Updates the release workflow to no longer build win32 binaries and add them to GH releases.