### PR TITLE
Bump Go to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module code.cloudfoundry.org/log-cache-cli/v4
 
-go 1.25.0
-
-toolchain go1.25.3
+go 1.26
 
 require (
 	code.cloudfoundry.org/cli v7.1.0+incompatible


### PR DESCRIPTION
Bumps the `go` directive to 1.26; Go 1.25 reached EOL on 2026-08-19, so we were shipping an EOL Go toolchain. `go mod tidy` run; vendored trees refreshed where applicable. CI / golangci-lint should be green.

Also removes the go toolchain from go.mod to harmonize it with other projects. See e.g. https://github.com/cloudfoundry/blackbox/commit/28cd21089c3821c8bd99b66ad6c5813451ff2560 where go toolchain has been removed from blackbox.

🤖 Generated with Claude Code (Opus, claude-opus-latest). Human-reviewed before submitting.